### PR TITLE
Fixed module creation to take an array of dependencies.

### DIFF
--- a/src/breakpoints.js
+++ b/src/breakpoints.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module("angular-enquire-breakpoints").directive('breakpoints',
+angular.module("angular-enquire-breakpoints", []).directive('breakpoints',
   [
     function() {
       return {


### PR DESCRIPTION
Error: [$injector:nomod] Module 'angular-enquire-breakpoints' is not available! You either misspelled the module name or forgot to load it. If registering a module ensure that you specify the dependencies as the second argument.
